### PR TITLE
Obtener nombre de los pdf a partir de metadata

### DIFF
--- a/src/helpers/Misc.ts
+++ b/src/helpers/Misc.ts
@@ -1,5 +1,6 @@
 import { initSync } from "gulagcleaner_wasm"
 import Log from "../constants/Log"
+import { PDFDocument } from 'pdf-lib';
 
 export default class Misc {
   private static logValues = Object.values(Log)
@@ -35,6 +36,21 @@ export default class Misc {
       header += b.toString(16);
     }
     return header === '255044462d'; // PDF header
+  }
+
+  static async extractPDFName(pdfBuffer : ArrayBuffer) {
+    try {
+      // Load the PDF from the buffer
+      const pdfDoc = await PDFDocument.load(pdfBuffer);
+            
+      // Extract the title from the metadata
+      const title = pdfDoc.getTitle() ?? 'Untitled';
+      
+      return title;
+    } catch (error) {
+      console.error('Error extracting PDF metadata:', error);
+      throw error;
+    }
   }
 
   static async initGulag(): Promise<void> {

--- a/src/interceptors/ObjectURL.ts
+++ b/src/interceptors/ObjectURL.ts
@@ -10,10 +10,11 @@ const { createObjectURL: origcreateObjectURL } = window.URL
  * Wrapper para abrir un Blob
  * @param obj Blob ya listo para descargar
  */
-const openBlob = (obj: Blob): void => {
+const openBlob = (obj: Blob, filename: string): void => {
   const url = origcreateObjectURL(obj)
   const a = document.createElement('a')
   a.setAttribute("href", url)
+  if (filename != '') a.setAttribute("download", filename)
   a.setAttribute("target", "_blank")
   a.click()
 }
@@ -48,9 +49,11 @@ const objectURLWrapper = (obj: Blob | MediaSource): string => {
   // Conseguimos los datos y vemos si los headers son los de un pdf
   obj.arrayBuffer().then(async (buf) => {
     if (!Misc.isPdf(buf)) {
-      openBlob(obj)
+      openBlob(obj, '')
       return
     }
+
+    const title = Misc.extractPDFName(buf)
 
     Misc.log('Limpiando documento', Log.INFO)
 
@@ -71,7 +74,7 @@ const objectURLWrapper = (obj: Blob | MediaSource): string => {
 
     // Nuevo blob y abrimos
     const newBlob = new Blob([data], { type: "application/pdf" });
-    openBlob(newBlob)
+    openBlob(newBlob, await title)
   })
 
   return "javascript:void(0)" // Evitamos que se abra la version sin limpiar

--- a/src/interceptors/ObjectURL.ts
+++ b/src/interceptors/ObjectURL.ts
@@ -10,11 +10,11 @@ const { createObjectURL: origcreateObjectURL } = window.URL
  * Wrapper para abrir un Blob
  * @param obj Blob ya listo para descargar
  */
-const openBlob = (obj: Blob, filename: string): void => {
+const openBlob = (obj: Blob, filename: string = ''): void => {
   const url = origcreateObjectURL(obj)
   const a = document.createElement('a')
   a.setAttribute("href", url)
-  if (filename != '') a.setAttribute("download", filename)
+  if (filename !== '') a.setAttribute("download", filename)
   a.setAttribute("target", "_blank")
   a.click()
 }
@@ -49,7 +49,7 @@ const objectURLWrapper = (obj: Blob | MediaSource): string => {
   // Conseguimos los datos y vemos si los headers son los de un pdf
   obj.arrayBuffer().then(async (buf) => {
     if (!Misc.isPdf(buf)) {
-      openBlob(obj, '')
+      openBlob(obj)
       return
     }
 


### PR DESCRIPTION
No sería la solución perfecta, porque hay documentos que no tienen título. Pero la mayoría si lo tienen.
Lo suyo sería obtener el título que el autor puso en wuolah.