### PR TITLE
Descargar elementos de carpetas en formato zip con JSZip 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "gulagcleaner_wasm": "^0.12.2",
-    "pdf-lib": "^1.17.1"
+    "pdf-lib": "^1.17.1",
+    "jszip": "2.6.1"
   }
 }

--- a/src/constants/Hooks.ts
+++ b/src/constants/Hooks.ts
@@ -92,6 +92,7 @@ export default class Hooks {
    * @todo Gestionar captchas
    */
   static folderDownload(res: Response) {
+    var zip2 = new JSZip();
     const url = res.url;
     const id = parseInt(url.substring(url.lastIndexOf("/") + 1));
 
@@ -121,13 +122,20 @@ export default class Hooks {
           }
 
           const blob = new Blob([buf], options);
-          openBlob(blob, doc.name);
+          zip2.file(await title, buf, {binary: true})
           i++;
         } else {
           failed = true;
           alert(`No se pudo descargar el archivo ${doc.name}, ¿quizás es un problema de captcha? Se ha interrumpido la descarga de la carpeta`);
         }
       }
+      const a = document.createElement('a');
+            a.setAttribute("target", "_blank");
+            a.click();
+            a.href = "data:application/zip;base64," + zip2.generate();
+            a.download = id;
+            a.click();
+            a.remove();
     });
   }
 }


### PR DESCRIPTION
Añadiendo JSZip version 2.6.1 podemos añadir el buffer de cada elemento de la carpeta a un archivo zip que será descargado posteriormente. 

__Aspectos a mejorar:__  Tras varias descargas suele fallar el script debido a los siguientes motivos:
- Codigos de error: `403` y/o `409`
- Captcha