### PR TITLE
Updated gulagcleaner to v0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "gulagcleaner_wasm": "^0.12.2",
+    "gulagcleaner_wasm": "^0.14.1",
     "jszip": "3.9.1",
     "pdf-lib": "^1.17.1"
   }


### PR DESCRIPTION
Hey @pablouser1!

There was a small update to Wuolah today that broke the gulagcleaner method, it should be fixed now with [v0.14.1](https://github.com/YM162/gulagcleaner/releases/v0.14.1).

This PR should fix #18  :)

Have a nice day! 