### PR TITLE
Bump gulagcleaner 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wuolahextra",
   "displayName": "WuolahExtra",
   "description": "UserScript para Wuolah",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "homepage": "https://github.com/pablouser1/WuolahExtra",
   "license": "MIT",
   "author": "Pablo Ferreiro",
@@ -25,7 +25,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "gulagcleaner_wasm": "^0.15.6",
+    "gulagcleaner_wasm": "^0.16.0",
     "jszip": "3.9.1",
     "pdf-lib": "^1.17.1"
   }


### PR DESCRIPTION
Este cambio arregla el reciente fallo en la clasificación de páginas de Gulag cleaner.