### PR TITLE
 feat(folder-download): resume after captcha and use folder name for zip 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import FetchWrapper from "./wrappers/Fetch";
 import { addOptions } from "./ui";
 import ClearMethods from "./constants/ClearMethods";
 import objectURLWrapper from "./wrappers/ObjectURL";
+import { CaptchaCounterDebugUI } from "./ui";
 
 // fix issue with unsafeWindow.URL
 declare const unsafeWindow: Window & typeof globalThis;
@@ -65,6 +66,11 @@ GM_config.init({
       // Modo debug en fetch hook
       if (GM_config.get("debug")) {
         fetchWrapper.setDebug(true);
+        try {
+          const ui = new CaptchaCounterDebugUI();
+          ui.start(3000);
+        } catch {
+        }
       }
 
       const clearMethod = GM_config.get("clear_pdf").toString();

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,1 +1,0 @@
-export const addOptions = () => GM.registerMenuCommand("Config", () => GM_config.open());

--- a/src/ui/CaptchaCounterDebugUI.ts
+++ b/src/ui/CaptchaCounterDebugUI.ts
@@ -1,0 +1,111 @@
+import Api from "../helpers/Api";
+
+export default class CaptchaCounterDebugUI {
+  private container: HTMLDivElement;
+  private valueEl: HTMLSpanElement;
+  private timerId: number | null = null;
+  private closed = false;
+
+  constructor() {
+    const existing = document.getElementById("wuolahextra-captcha-debug");
+    if (existing) {
+      existing.remove();
+    }
+
+    this.container = document.createElement("div");
+    this.container.id = "wuolahextra-captcha-debug";
+    this.container.style.position = "fixed";
+    this.container.style.top = "12px";
+    this.container.style.right = "12px";
+    this.container.style.zIndex = "2147483647";
+    this.container.style.background = "rgba(17, 17, 17, 0.92)";
+    this.container.style.color = "#fff";
+    this.container.style.border = "1px solid rgba(255,255,255,0.15)";
+    this.container.style.borderRadius = "10px";
+    this.container.style.padding = "8px 10px";
+    this.container.style.fontFamily =
+      "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif";
+    this.container.style.fontSize = "12px";
+    this.container.style.boxShadow = "0 6px 24px rgba(0,0,0,0.35)";
+    this.container.style.minWidth = "180px";
+
+    const header = document.createElement("div");
+    header.style.display = "flex";
+    header.style.alignItems = "center";
+    header.style.justifyContent = "space-between";
+    header.style.marginBottom = "6px";
+
+    const title = document.createElement("div");
+    title.textContent = "WuolahExtra Debug";
+    title.style.fontWeight = "600";
+
+    const close = document.createElement("button");
+    close.type = "button";
+    close.textContent = "×";
+    close.style.background = "transparent";
+    close.style.border = "none";
+    close.style.color = "rgba(255,255,255,0.85)";
+    close.style.cursor = "pointer";
+    close.style.fontSize = "16px";
+    close.style.lineHeight = "16px";
+    close.style.padding = "0 2px";
+
+    close.addEventListener("click", () => this.stop());
+
+    header.appendChild(title);
+    header.appendChild(close);
+
+    const line = document.createElement("div");
+    line.style.opacity = "0.9";
+
+    const label = document.createElement("span");
+    label.textContent = "captchaCounter: ";
+
+    this.valueEl = document.createElement("span");
+    this.valueEl.textContent = "…";
+    this.valueEl.style.fontWeight = "600";
+
+    line.appendChild(label);
+    line.appendChild(this.valueEl);
+
+    this.container.appendChild(header);
+    this.container.appendChild(line);
+
+    (document.body || document.documentElement).appendChild(this.container);
+  }
+
+  start(intervalMs: number = 3000): void {
+    if (this.timerId !== null || this.closed) {
+      return;
+    }
+
+    const tick = async () => {
+      if (this.closed) {
+        return;
+      }
+      try {
+        const me = await Api.me();
+        const value = typeof me.captchaCounter === "number" ? me.captchaCounter : null;
+        this.valueEl.textContent = value === null ? "(n/a)" : value.toString();
+        this.valueEl.style.color = "#fff";
+      } catch {
+        this.valueEl.textContent = "(error)";
+        this.valueEl.style.color = "#fca5a5";
+      }
+    };
+
+    void tick();
+    this.timerId = window.setInterval(() => {
+      void tick();
+    }, intervalMs);
+  }
+
+  stop(): void {
+    this.closed = true;
+    if (this.timerId !== null) {
+      window.clearInterval(this.timerId);
+      this.timerId = null;
+    }
+    this.container.remove();
+  }
+}

--- a/src/ui/ProgressUI.ts
+++ b/src/ui/ProgressUI.ts
@@ -1,0 +1,190 @@
+export default class ProgressUI {
+  private container: HTMLDivElement;
+  private titleEl: HTMLDivElement;
+  private statusEl: HTMLDivElement;
+  private progressOuter: HTMLDivElement;
+  private progressInner: HTMLDivElement;
+  private cancelBtn: HTMLButtonElement;
+  private actionBtn: HTMLButtonElement | null = null;
+  private cancelListeners: Array<() => void> = [];
+
+  private total: number | null = null;
+  private cancelled = false;
+
+  constructor(title: string) {
+    const existing = document.getElementById("wuolahextra-folder-progress");
+    if (existing) {
+      existing.remove();
+    }
+
+    this.container = document.createElement("div");
+    this.container.id = "wuolahextra-folder-progress";
+    this.container.style.position = "fixed";
+    this.container.style.right = "16px";
+    this.container.style.bottom = "16px";
+    this.container.style.zIndex = "2147483647";
+    this.container.style.background = "rgba(20, 20, 20, 0.95)";
+    this.container.style.color = "#fff";
+    this.container.style.border = "1px solid rgba(255,255,255,0.15)";
+    this.container.style.borderRadius = "10px";
+    this.container.style.padding = "12px";
+    this.container.style.width = "320px";
+    this.container.style.fontFamily =
+      "system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif";
+    this.container.style.fontSize = "13px";
+    this.container.style.boxShadow = "0 8px 30px rgba(0,0,0,0.35)";
+
+    this.titleEl = document.createElement("div");
+    this.titleEl.textContent = title;
+    this.titleEl.style.fontWeight = "600";
+    this.titleEl.style.marginBottom = "6px";
+
+    this.statusEl = document.createElement("div");
+    this.statusEl.textContent = "Iniciando…";
+    this.statusEl.style.opacity = "0.9";
+    this.statusEl.style.marginBottom = "10px";
+    this.statusEl.style.wordBreak = "break-word";
+    this.statusEl.style.whiteSpace = "pre-line";
+
+    this.progressOuter = document.createElement("div");
+    this.progressOuter.style.height = "8px";
+    this.progressOuter.style.background = "rgba(255,255,255,0.12)";
+    this.progressOuter.style.borderRadius = "999px";
+    this.progressOuter.style.overflow = "hidden";
+    this.progressOuter.style.marginBottom = "10px";
+
+    this.progressInner = document.createElement("div");
+    this.progressInner.style.height = "100%";
+    this.progressInner.style.width = "0%";
+    this.progressInner.style.background = "#3b82f6";
+    this.progressInner.style.transition = "width 150ms linear";
+    this.progressOuter.appendChild(this.progressInner);
+
+    this.cancelBtn = document.createElement("button");
+    this.cancelBtn.type = "button";
+    this.cancelBtn.textContent = "Cancelar";
+    this.cancelBtn.style.background = "transparent";
+    this.cancelBtn.style.color = "#fff";
+    this.cancelBtn.style.border = "1px solid rgba(255,255,255,0.2)";
+    this.cancelBtn.style.borderRadius = "8px";
+    this.cancelBtn.style.padding = "6px 10px";
+    this.cancelBtn.style.cursor = "pointer";
+
+    const footer = document.createElement("div");
+    footer.style.display = "flex";
+    footer.style.justifyContent = "flex-end";
+    footer.appendChild(this.cancelBtn);
+
+    this.container.appendChild(this.titleEl);
+    this.container.appendChild(this.statusEl);
+    this.container.appendChild(this.progressOuter);
+    this.container.appendChild(footer);
+
+    document.body.appendChild(this.container);
+
+    this.cancelBtn.addEventListener("click", () => {
+      this.cancelled = true;
+      this.cancelBtn.disabled = true;
+      this.cancelBtn.textContent = "Cancelado";
+      this.setError("Cancelando…");
+
+      const listeners = this.cancelListeners;
+      this.cancelListeners = [];
+      for (const cb of listeners) {
+        try {
+          cb();
+        } catch {
+        }
+      }
+    });
+  }
+
+  isCancelled(): boolean {
+    return this.cancelled;
+  }
+
+  setTotal(total: number): void {
+    this.total = total;
+  }
+
+  setStatus(text: string): void {
+    this.statusEl.style.color = "#fff";
+    this.statusEl.style.opacity = "0.9";
+    this.progressInner.style.background = "#3b82f6";
+    this.statusEl.textContent = text;
+  }
+
+  setAction(label: string, onClick: () => void): void {
+    if (!this.actionBtn) {
+      this.actionBtn = document.createElement("button");
+      this.actionBtn.type = "button";
+      this.actionBtn.style.background = "#2563eb";
+      this.actionBtn.style.color = "#fff";
+      this.actionBtn.style.border = "1px solid rgba(255,255,255,0.15)";
+      this.actionBtn.style.borderRadius = "8px";
+      this.actionBtn.style.padding = "6px 10px";
+      this.actionBtn.style.cursor = "pointer";
+      this.actionBtn.style.marginRight = "8px";
+
+      const footer = this.container.lastElementChild as HTMLDivElement;
+      footer.style.justifyContent = "space-between";
+      footer.style.gap = "8px";
+      footer.prepend(this.actionBtn);
+    }
+
+    this.actionBtn.textContent = label;
+    this.actionBtn.disabled = false;
+    this.actionBtn.onclick = () => {
+      if (this.cancelled) {
+        return;
+      }
+      onClick();
+    };
+  }
+
+  clearAction(): void {
+    if (this.actionBtn) {
+      this.actionBtn.remove();
+      this.actionBtn = null;
+      const footer = this.container.lastElementChild as HTMLDivElement;
+      footer.style.justifyContent = "flex-end";
+    }
+  }
+
+  onCancel(cb: () => void): void {
+    if (this.cancelled) {
+      cb();
+      return;
+    }
+    this.cancelListeners.push(cb);
+  }
+
+  setProgress(done: number, total?: number): void {
+    const t = total ?? this.total;
+    if (!t || t <= 0) {
+      return;
+    }
+    const pct = Math.max(0, Math.min(100, Math.round((done / t) * 100)));
+    this.progressInner.style.width = `${pct}%`;
+  }
+
+  setError(text: string): void {
+    this.statusEl.textContent = text;
+    this.statusEl.style.color = "#fca5a5";
+    this.progressInner.style.background = "#ef4444";
+  }
+
+  done(text: string): void {
+    this.statusEl.textContent = text;
+    this.statusEl.style.color = "#86efac";
+    this.progressInner.style.width = "100%";
+    this.progressInner.style.background = "#22c55e";
+    this.cancelBtn.disabled = true;
+    this.cancelBtn.textContent = "Cerrar";
+    this.cancelBtn.onclick = () => this.remove();
+  }
+
+  remove(): void {
+    this.container.remove();
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,5 @@
+export { default as CaptchaCounterDebugUI } from "./CaptchaCounterDebugUI";
+export { default as ProgressUI } from "./ProgressUI";
+
+export const addOptions = () => GM.registerMenuCommand("Config", () => GM_config.open());
+

--- a/src/wrappers/Hooks.ts
+++ b/src/wrappers/Hooks.ts
@@ -93,7 +93,13 @@ export default class Hooks {
           .json()
           .then((d) => ({
             ...d, item: {
-              theme: "wuolah-theme-dark"
+              theme: {
+                id: "wuolah-theme-dark",
+                properties: {
+                  colorSchemeAlias: "wuolah-color-scheme-dark",
+                  previewUrl: "https://cdn.wuolahservices.com/features/themes/default/preview.png"
+                }
+              }
             }
           }));
       res.json = json;

--- a/src/wrappers/Hooks.ts
+++ b/src/wrappers/Hooks.ts
@@ -4,6 +4,7 @@ import { HookAfter, HookBefore } from "../types/Hooks";
 import Log from "../constants/Log";
 import handlePDF from "../helpers/Cleaner";
 import JSZip from "jszip";
+import { ProgressUI } from "../ui";
 
 /**
  * Hooks de Fetch
@@ -130,46 +131,235 @@ export default class Hooks {
     const url = res.url;
     const id = parseInt(url.substring(url.lastIndexOf("/") + 1));
 
+    const progress = new ProgressUI(`Descargando carpeta ${id}`);
+    progress.setStatus("Obteniendo información de la carpeta…");
+
     if (isNaN(id)) {
       Misc.log("¡Error al obtener id de la carpeta!", Log.INFO);
+      progress.setError("Error: no se pudo obtener el ID de la carpeta");
       return;
     }
 
     Misc.log(`Descargando carpeta ${id}`, Log.INFO);
 
-    Api.folder(id).then(async (docs) => {
-      let failed = false;
-      let i = 0;
-      while (!failed && i < docs.length) {
-        const doc = docs[i];
-        const url = await Api.docUrl(doc.id);
+    Api.uploadInfo(id).then((info) => {
+      const sanitizeFilename = (name: string): string => {
+        return name.replace(/[\\/:*?\"<>|]+/g, "_").trim();
+      };
 
-        if (url !== null) {
-          let buf = await Api.docData(url);
+      const folderName = sanitizeFilename(info?.name || id.toString()) || id.toString();
+      progress.setStatus("Listando documentos…");
 
-          if (doc.fileType === "application/pdf") {
-            buf = await handlePDF(buf);
+      Api.folder(id).then(async (docs) => {
+        progress.setTotal(docs.length);
+        progress.setProgress(0, docs.length);
+
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+        const getCaptchaCounter = async (): Promise<number | null> => {
+          try {
+            const me = await Api.me();
+            return typeof me.captchaCounter === "number" ? me.captchaCounter : null;
+          } catch {
+            return null;
+          }
+        };
+
+        const waitForCaptchaCounterPositive = async (): Promise<boolean> => {
+          let lastShown: number | null = null;
+          while (!progress.isCancelled()) {
+            const current = await getCaptchaCounter();
+            if (current !== null && current !== lastShown) {
+              lastShown = current;
+              progress.setError(
+                `Esperando captcha…\n` +
+                `Descargas disponibles: ${current}\n` +
+                `Cuando completes el captcha en Wuolah, el script seguirá automáticamente.`
+              );
+            }
+
+            if (current !== null && current > 0) {
+              return true;
+            }
+            await sleep(1000);
+          }
+          return false;
+        };
+
+        let captchaExplained = false;
+
+        try {
+          progress.setStatus("Comprobando captchaCounter…");
+          const me = await Api.me();
+          const counter = typeof me.captchaCounter === "number" ? me.captchaCounter : null;
+          if (counter !== null && docs.length > counter) {
+            alert(
+              `Aviso: esta carpeta tiene ${docs.length} archivos, pero ahora mismo solo puedes descargar ${counter} archivos seguidos antes de que Wuolah te pida una verificación (captcha).\n\n` +
+              `La descarga se parará a la mitad. Cuando ocurra, el script te indicará qué hacer para continuar.`
+            );
+          }
+        } catch (e) {
+          Misc.log(`No se pudo comprobar captchaCounter: ${e}`, Log.DEBUG);
+        }
+
+        let isPaused = false;
+        let availableTokens: number | null = await getCaptchaCounter();
+        let pausePromise: Promise<boolean> | null = null;
+        let pauseResolver: ((v: boolean) => void) | null = null;
+
+        let completed = 0;
+        let failed = false;
+        let fatalError: string | null = null;
+
+        const setStatusSafe = (text: string) => {
+          if (!isPaused && !failed && !progress.isCancelled()) {
+            progress.setStatus(text);
+          }
+        };
+
+        const refreshTokens = async () => {
+          const t = await getCaptchaCounter();
+          availableTokens = t;
+          return t;
+        };
+
+        const waitIfPaused = async (): Promise<boolean> => {
+          if (isPaused && pausePromise) {
+            return pausePromise;
+          }
+          return true;
+        };
+
+        const triggerPause = async (docName?: string): Promise<boolean> => {
+          if (isPaused) return waitIfPaused();
+
+          isPaused = true;
+          pausePromise = new Promise<boolean>((resolve) => {
+            pauseResolver = resolve;
+          });
+
+          await refreshTokens();
+
+          if (!captchaExplained) {
+            const ok = confirm(
+              `No se pudo continuar descargando${docName ? ` (${docName})` : ""} por culpa de un captcha.\n\n` +
+              `No cierres esta ventana!!\n\n` +
+              `Para seguir con la descarga de la carpeta:\n` +
+              `1) Descarga cualquier archivo individual desde la web de Wuolah para que aparezca el captcha (vale de esta misma carpeta)\n` +
+              `2) Resuélvelo\n` +
+              `3) El script continuará automáticamente\n\n` +
+              `Pulsa Cancelar para cancelar la descarga de la carpeta.`
+            );
+
+            if (!ok) {
+              isPaused = false;
+              pauseResolver?.(false);
+              return false;
+            }
+            captchaExplained = true;
           }
 
-          zip.file(doc.name, buf, { binary: true })
-          i++;
-        } else {
-          failed = true;
-          alert(`No se pudo descargar el archivo ${doc.name}, ¿quizás es un problema de captcha? Se ha interrumpido la descarga de la carpeta`);
-        }
-      }
+          progress.setError(
+            `Esperando captcha${docName ? `: ${docName}` : ""}\n` +
+            `Resuélvelo en Wuolah. El script continuará automáticamente cuando puedas volver a descargar.`
+          );
 
-      if (!failed) {
-        zip.generateAsync({ type: "base64" }).then(bs64 => {
-          const a = document.createElement('a');
-          a.href = "data:application/zip;base64," + bs64;
-          a.setAttribute("download", `${id}.zip`);
-          a.click();
-          a.remove();
-        }).catch(err => {
-          Misc.log(err, Log.ERROR);
-        })
-      }
+          const resumed = await waitForCaptchaCounterPositive();
+          await refreshTokens();
+
+          isPaused = false;
+          pauseResolver?.(resumed);
+          return resumed;
+        };
+
+        let nextDocIndex = 0;
+        const maxConcurrency = 4;
+        const concurrency = Math.max(1, Math.min(maxConcurrency, docs.length));
+
+        const workers = Array.from({ length: concurrency }, async () => {
+          while (nextDocIndex < docs.length) {
+            if (completed + (failed ? 1 : 0) >= docs.length) break;
+            if (progress.isCancelled() || failed) return;
+
+            const myIndex = nextDocIndex++;
+            if (myIndex >= docs.length) break;
+            const doc = docs[myIndex];
+
+            let success = false;
+            while (!success && !failed && !progress.isCancelled()) {
+              if (isPaused) {
+                if (!await waitIfPaused()) return;
+              }
+
+              if (availableTokens !== null && availableTokens <= 0) {
+                if (!await triggerPause()) return;
+                continue;
+              }
+
+              if (availableTokens !== null) availableTokens--;
+
+              try {
+                setStatusSafe(`Descargando ${completed + 1}/${docs.length}: ${doc.name}`);
+                const dl = await Api.docUrlResult(doc.id);
+
+                if (dl.url !== null) {
+                  let buf = await Api.docData(dl.url);
+                  if (doc.fileType === "application/pdf") {
+                    setStatusSafe(`Limpiando PDF (${completed + 1}/${docs.length}): ${doc.name}`);
+                    buf = await handlePDF(buf);
+                  }
+
+                  zip.file(doc.name, buf, { binary: true });
+                  completed++;
+                  progress.setProgress(completed, docs.length);
+                  setStatusSafe(`Completado ${completed}/${docs.length}`);
+                  success = true;
+                } else {
+                  if (availableTokens !== null) availableTokens++;
+
+                  if (dl.status === 429 && dl.code === "FI008") {
+                    if (!await triggerPause(doc.name)) return;
+                  } else {
+                    throw new Error(`download failed (status ${dl.status}${dl.code ? `, code ${dl.code}` : ""})`);
+                  }
+                }
+              } catch (e) {
+                failed = true;
+                fatalError = e instanceof Error ? e.message : String(e);
+                return;
+              }
+            }
+          }
+        });
+
+        await Promise.all(workers);
+
+        if (!failed) {
+          progress.setStatus("Generando ZIP…");
+          progress.setProgress(docs.length, docs.length);
+          zip.generateAsync({ type: "base64" }).then(bs64 => {
+            const a = document.createElement('a');
+            a.href = "data:application/zip;base64," + bs64;
+            a.setAttribute("download", `${folderName}.zip`);
+            a.click();
+            a.remove();
+            progress.done(`ZIP listo: ${folderName}.zip`);
+            setTimeout(() => progress.remove(), 5000);
+          }).catch(err => {
+            Misc.log(err, Log.ERROR);
+            progress.setError("Error generando el ZIP");
+          })
+        } else {
+          if (progress.isCancelled()) {
+            progress.setError("Descarga cancelada por el usuario");
+          } else {
+            progress.setError(`Descarga interrumpida${fatalError ? `\n${fatalError}` : ""}`);
+          }
+        }
+      });
+    }).catch(err => {
+      Misc.log(`Error al obtener info de la carpeta: ${err}`, Log.ERROR);
+      progress.setError("Error obteniendo la información de la carpeta");
     });
   }
 }


### PR DESCRIPTION
Lo que pone, permite que las carpetas descargadas tengan el nombre real y si no la id.
Además permite que aunque salte error de captcha en medio de la descarga de una carpeta continue una vez se resuelva uno (lo que cambia el contador captchaCounter del endpoint  /me).

Fotos del flujo:
<img width="514" height="207" alt="2026-01-10_02-34-40" src="https://github.com/user-attachments/assets/fe18e6a6-c39d-4069-b8cf-724aa6367687" />
<img width="480" height="310" alt="2026-01-10_02-35-04" src="https://github.com/user-attachments/assets/5918383b-466d-4a7b-b002-7c0045b8385a" />
<img width="482" height="477" alt="2026-01-10_02-35-18" src="https://github.com/user-attachments/assets/0914f1a7-0031-4172-b5f5-8f1d4d28679f" />
<img width="356" height="192" alt="2026-01-10_02-35-33" src="https://github.com/user-attachments/assets/30dc0fe7-8a39-42ff-9ec9-a9fb88a6d047" />
<img width="340" height="147" alt="2026-01-10_02-37-22" src="https://github.com/user-attachments/assets/bb9f449c-e6ee-4715-9ec7-1669e9cc1669" />


De paso arreglé también el force-dark que había cambiado la respuesta del server un poco. Se ve horrible porque los modales no los tienen configurados con el modo oscuro pero it is what it is `¯\_(ツ)_/¯`